### PR TITLE
POC: nice ticks w/ configured timezone for x-axis

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/WatcherFlyout.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/WatcherFlyout.tsx
@@ -26,11 +26,10 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
-import { memoize, padLeft, range } from 'lodash';
+import { padLeft, range } from 'lodash';
 import moment from 'moment-timezone';
 import React, { Component } from 'react';
 import styled from 'styled-components';
-import { LegacyCoreStart } from 'src/core/public';
 import { KibanaCoreContext } from '../../../../../../observability/public';
 import { IUrlParams } from '../../../../context/UrlParamsContext/types';
 import { KibanaLink } from '../../../shared/Links/KibanaLink';
@@ -38,12 +37,6 @@ import { createErrorGroupWatch, Schedule } from './createErrorGroupWatch';
 import { ElasticDocsLink } from '../../../shared/Links/ElasticDocsLink';
 
 type ScheduleKey = keyof Schedule;
-
-const getUserTimezone = memoize((core: LegacyCoreStart): string => {
-  return core.uiSettings.get('dateFormat:tz') === 'Browser'
-    ? moment.tz.guess()
-    : core.uiSettings.get('dateFormat:tz');
-});
 
 const SmallInput = styled.div`
   .euiFormRow {
@@ -284,17 +277,13 @@ export class WatcherFlyout extends Component<
       return null;
     }
 
-    const core = this.context;
-    const userTimezoneSetting = getUserTimezone(core);
     const dailyTime = this.state.daily;
     const inputTime = `${dailyTime}Z`; // Add tz to make into UTC
     const inputFormat = 'HH:mmZ'; // Parse as 24 hour w. tz
-    const dailyTimeFormatted = moment(inputTime, inputFormat)
-      .tz(userTimezoneSetting)
-      .format('HH:mm'); // Format as 24h
-    const dailyTime12HourFormatted = moment(inputTime, inputFormat)
-      .tz(userTimezoneSetting)
-      .format('hh:mm A (z)'); // Format as 12h w. tz
+    const dailyTimeFormatted = moment(inputTime, inputFormat).format('HH:mm'); // Format as 24h
+    const dailyTime12HourFormatted = moment(inputTime, inputFormat).format(
+      'hh:mm A (z)'
+    ); // Format as 12h w. tz
 
     // Generate UTC hours for Daily Report select field
     const intervalHours = range(24).map(i => {

--- a/x-pack/legacy/plugins/apm/public/components/shared/TimestampTooltip/index.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/TimestampTooltip/index.test.tsx
@@ -17,17 +17,16 @@ describe('TimestampTooltip', () => {
     // mock Date.now
     mockNow(1570737000000);
 
-    // hardcode timezone to avoid timezone issues on CI
-    jest
-      .spyOn(moment.tz, 'guess')
-      .mockImplementation(() => 'Europe/Copenhagen');
+    moment.tz.setDefault('Etc/GMT');
   });
+
+  afterAll(() => moment.tz.setDefault(''));
 
   it('should render component with relative time in body and absolute time in tooltip', () => {
     expect(shallow(<TimestampTooltip time={timestamp} />))
       .toMatchInlineSnapshot(`
       <EuiToolTip
-        content="Oct 10th 2019, 17:06:40.123 (+0200 CEST)"
+        content="Oct 10th 2019, 15:06:40.123 (+0000 GMT)"
         delay="regular"
         position="top"
       >
@@ -41,7 +40,7 @@ describe('TimestampTooltip', () => {
       shallow(<TimestampTooltip time={timestamp} />)
         .find('EuiToolTip')
         .prop('content')
-    ).toBe('Oct 10th 2019, 17:06:40.123 (+0200 CEST)');
+    ).toBe('Oct 10th 2019, 15:06:40.123 (+0000 GMT)');
   });
 
   it('should format with precision in minutes', () => {
@@ -49,7 +48,7 @@ describe('TimestampTooltip', () => {
       shallow(<TimestampTooltip time={timestamp} precision="minutes" />)
         .find('EuiToolTip')
         .prop('content')
-    ).toBe('Oct 10th 2019, 17:06 (+0200 CEST)');
+    ).toBe('Oct 10th 2019, 15:06 (+0000 GMT)');
   });
 
   it('should format with precision in days', () => {
@@ -57,6 +56,6 @@ describe('TimestampTooltip', () => {
       shallow(<TimestampTooltip time={timestamp} precision="days" />)
         .find('EuiToolTip')
         .prop('content')
-    ).toBe('Oct 10th 2019 (+0200 CEST)');
+    ).toBe('Oct 10th 2019 (+0000 GMT)');
   });
 });

--- a/x-pack/legacy/plugins/apm/public/components/shared/TimestampTooltip/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/TimestampTooltip/index.tsx
@@ -27,7 +27,7 @@ function getPreciseTime(precision: Props['precision']) {
 }
 
 export function TimestampTooltip({ time, precision = 'milliseconds' }: Props) {
-  const momentTime = moment.tz(time, moment.tz.guess());
+  const momentTime = moment(time);
   const relativeTimeLabel = momentTime.fromNow();
   const absoluteTimeLabel = momentTime.format(
     `MMM Do YYYY${getPreciseTime(precision)} (ZZ zz)`

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/StaticPlot.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/StaticPlot.js
@@ -17,11 +17,13 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { last } from 'lodash';
 import { rgba } from 'polished';
+import { scaleUtc } from 'd3-scale';
 
 import StatusText from './StatusText';
 import { SharedPlot } from './plotUtils';
 import { i18n } from '@kbn/i18n';
 import { isValidCoordinateValue } from '../../../../utils/isValidCoordinateValue';
+import { getTimezoneOffsetInMs } from './getTimezoneOffsetInMs';
 
 // undefined values are converted by react-vis into NaN when stacking
 // see https://github.com/uber/react-vis/issues/1214
@@ -42,7 +44,7 @@ class StaticPlot extends PureComponent {
           <LineSeries
             getNull={getNull}
             key={serie.title}
-            xType="time"
+            xType="time-utc"
             curve={'curveMonotoneX'}
             data={serie.data}
             color={serie.color}
@@ -54,7 +56,7 @@ class StaticPlot extends PureComponent {
           <AreaSeries
             getNull={getNull}
             key={serie.title}
-            xType="time"
+            xType="time-utc"
             curve={'curveMonotoneX'}
             data={serie.data}
             color={serie.color}
@@ -78,7 +80,7 @@ class StaticPlot extends PureComponent {
           <AreaSeries
             getNull={getNull}
             key={`${serie.title}-area`}
-            xType="time"
+            xType="time-utc"
             curve={'curveMonotoneX'}
             data={data}
             color={serie.color}
@@ -90,7 +92,7 @@ class StaticPlot extends PureComponent {
           <LineSeries
             getNull={getNull}
             key={`${serie.title}-line`}
-            xType="time"
+            xType="time-utc"
             curve={'curveMonotoneX'}
             data={data}
             color={serie.color}
@@ -113,7 +115,7 @@ class StaticPlot extends PureComponent {
           <VerticalRectSeries
             getNull={getNull}
             key={serie.title}
-            xType="time"
+            xType="time-utc"
             curve={'curveMonotoneX'}
             data={data}
             color={serie.color}
@@ -126,7 +128,7 @@ class StaticPlot extends PureComponent {
           <LineMarkSeries
             getNull={getNull}
             key={serie.title}
-            xType="time"
+            xType="time-utc"
             curve={'curveMonotoneX'}
             data={serie.data}
             color={serie.color}
@@ -138,24 +140,42 @@ class StaticPlot extends PureComponent {
     }
   }
 
+  /**
+   * A tick format function that takes the timezone from Kibana's settings into
+   * account. Used if no tickFormatX prop is supplied.
+   *
+   * This produces the same results as the built-in formatter from D3, which is
+   * what react-vis uses, but shifts the timezone.
+   */
+  tickFormatX = value => {
+    const xDomain = this.props.plotValues.x.domain();
+
+    const time = value.getTime();
+
+    return scaleUtc()
+      .domain(xDomain)
+      .tickFormat()(time - getTimezoneOffsetInMs(time));
+  };
+
   render() {
-    const {
-      width,
-      series,
-      tickFormatX,
-      tickFormatY,
-      plotValues,
-      noHits
-    } = this.props;
-    const { yTickValues } = plotValues;
+    const { width, series, tickFormatY, plotValues, noHits } = this.props;
+    const { xTickValues, yTickValues } = plotValues;
 
     // approximate number of x-axis ticks based on the width of the plot. There should by approx 1 tick per 100px
     // d3 will determine the exact number of ticks based on the selected range
     const xTickTotal = Math.floor(width / 100);
 
+    const tickFormatX = this.props.tickFormatX || this.tickFormatX;
+
     return (
       <SharedPlot plotValues={plotValues}>
-        <XAxis tickSize={0} tickTotal={xTickTotal} tickFormat={tickFormatX} />
+        <XAxis
+          type="time-utc"
+          tickSize={0}
+          tickTotal={xTickTotal}
+          tickFormat={tickFormatX}
+          tickValues={xTickValues}
+        />
         {noHits ? (
           <StatusText
             marginLeft={30}

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/getTimezoneOffsetInMs.ts
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/getTimezoneOffsetInMs.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import moment from 'moment';
+
+// @ts-ignore
+const zone = moment.defaultZone ? moment.defaultZone.name : moment.tz.guess();
+
+export function getTimezoneOffsetInMs(time: number) {
+  // @ts-ignore
+  return moment.tz.zone(zone).parse(time) * 60000;
+}

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/Histogram/index.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/Histogram/index.js
@@ -123,7 +123,8 @@ export class HistogramInner extends PureComponent {
     const xDomain = x.domain();
     const yDomain = y.domain();
     const yTickValues = [0, yDomain[1] / 2, yDomain[1]];
-    const isTimeSeries = this.props.xType === 'time';
+    const isTimeSeries =
+      this.props.xType === 'time' || this.props.xType === 'time-utc';
     const shouldShowTooltip =
       hoveredBucket.x > 0 && (hoveredBucket.y > 0 || isTimeSeries);
 

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/Tooltip/index.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/Tooltip/index.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import { isEmpty } from 'lodash';
 import { Hint } from 'react-vis';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import {
@@ -69,6 +69,16 @@ const Value = styled.div`
   font-size: ${fontSize};
 `;
 
+/**
+ * Format the time for the tooltip header.
+ *
+ * Since the x-axis is always using local time, we display the date in local time
+ * instead of the users preferred timezone.
+ */
+function headerTime(date) {
+  return moment.tz(date, moment.tz.guess()).format('MMMM Do YYYY, HH:mm:ss');
+}
+
 export default function Tooltip({
   header,
   footer,
@@ -87,8 +97,7 @@ export default function Tooltip({
   return (
     <Hint {...props} value={{ x, y }}>
       <TooltipElm>
-        <Header>{header || moment(x).format('MMMM Do YYYY, HH:mm:ss')}</Header>
-
+        <Header>{header || headerTime(x)}</Header>
         <Content>
           {showLegends ? (
             tooltipPoints.map((point, i) => (


### PR DESCRIPTION
This is a POC that demonstrates a possible solution (I _think_) for the time ticks. The idea:

- create nice ticks for the configured timezone (ie at 1w, 1d, 12hrs interval) by offsetting the xMin/xMax
- explicitly pass those tick values to the x-axis
- when formatting, use `scaleUtc` to format everything as UTC, and offset the time again with the configured timezone.

Lots of rough edges but I think this could be the solution. I'm not smart enough to figure out what would happen when we cover a time range when the time offset shifts (e.g. when DST kicks in).